### PR TITLE
[2/2] Settings: allow stopping pinned mode for non-navbar devices

### DIFF
--- a/src/com/android/settings/ScreenPinningSettings.java
+++ b/src/com/android/settings/ScreenPinningSettings.java
@@ -79,6 +79,8 @@ public class ScreenPinningSettings extends SettingsPreferenceFragment
     private void setLockToAppEnabled(boolean isEnabled) {
         Settings.System.putInt(getContentResolver(), Settings.System.LOCK_TO_APP_ENABLED,
                 isEnabled ? 1 : 0);
+        // always reset the hide dialog flag
+        Settings.System.putInt(getContentResolver(), Settings.System.LOCK_TO_APP_HIDE_DIALOG, 0);
     }
 
     /**


### PR DESCRIPTION
add an "always show" checkbox to bypass showing the warning dialog
this will be reset when you disable/enable pinning mode in settings

Change-Id: Iefbb0749a32f533999276d5e2bd810b100f825a2
